### PR TITLE
Added support for easy-install.pth files

### DIFF
--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -188,7 +188,8 @@ def update_paths(base, new_path):
     update_scripts(bin_dir, new_path)
     update_pycs(lib_dir, new_path, lib_name)
     update_local(base, new_path)
-    update_pth_files(easy_install_pth, new_path)
+    if os.path.isfile(easy_install_pth):
+        update_pth_files(easy_install_pth, new_path)
 
     return True
 


### PR DESCRIPTION
When you are using git sources in editable mode - a module is installed into src/ directory of virtualenv. And this directory is included in path via easy-install.pth file containing full path to src directory.
This patch fixes path in such files.
