### PR TITLE
Support virtualenvs created with --python=/usr/bin/pythonX.Y rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 .DS_Store
 dist
+build

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='virtualenv-tools',
     author='Fireteam Ltd.',
     author_email='support@fireteam.net',
-    version='1.0',
+    version='1.0.1',
     url='http://github.com/fireteam/virtualenv-tools',
     py_modules=['virtualenv_tools'],
     description='A set of tools for virtualenv',

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -26,6 +26,7 @@ ACTIVATION_SCRIPTS = [
 ]
 _pybin_match = re.compile(r'^python\d+\.\d+$')
 _activation_path_re = re.compile(r'^(?:set -gx |setenv |)VIRTUAL_ENV[ =]"(.*?)"\s*$')
+_shebang_bin_re = re.compile(r'.*/bin/python(\d+(\.\d+)?)?$')
 
 
 def update_activation_script(script_filename, new_path):
@@ -65,11 +66,13 @@ def update_script(script_filename, new_path):
     if not args:
         return
 
-    if not args[0].endswith('/bin/python') or \
+    if not _shebang_bin_re.match(args[0]) or \
        '/usr/bin/env python' in args[0]:
         return
 
-    new_bin = os.path.join(new_path, 'bin', 'python')
+    python = args[0].split('/')[-1]
+
+    new_bin = os.path.join(new_path, 'bin', python)
     if new_bin == args[0]:
         return
 

--- a/virtualenv_tools.py
+++ b/virtualenv_tools.py
@@ -26,7 +26,7 @@ ACTIVATION_SCRIPTS = [
 ]
 _pybin_match = re.compile(r'^python\d+\.\d+$')
 _activation_path_re = re.compile(r'^(?:set -gx |setenv |)VIRTUAL_ENV[ =]"(.*?)"\s*$')
-_shebang_bin_re = re.compile(r'.*/bin/python(\d+(\.\d+)?)?$')
+_shebang_bin_re = re.compile(r'.*/bin/python(\d+(\.?\d+)?)?$')
 
 
 def update_activation_script(script_filename, new_path):


### PR DESCRIPTION
Supersedes https://github.com/fireteam/virtualenv-tools/pull/7 and https://github.com/fireteam/virtualenv-tools/pull/4. Updated the regular expression to make the version decimal optional, as it does not appear on some platforms.
